### PR TITLE
Fix ECS BuildRequest and clean up physics reference

### DIFF
--- a/Assets/Scripts/BuildRequest.cs
+++ b/Assets/Scripts/BuildRequest.cs
@@ -1,10 +1,9 @@
 using Unity.Entities;
 using Unity.Mathematics;
-using UnityEngine;
 
 public struct BuildRequest : IComponentData
 {
-    public GameObject Prefab;
+    public Entity Prefab;
     public int Cost;
     public float3 BasePosition;
 }

--- a/Assets/Scripts/BuildUI.cs
+++ b/Assets/Scripts/BuildUI.cs
@@ -10,16 +10,24 @@ public class BuildUI : MonoBehaviour
     public BaseAuthoring BaseRef;
     public UnityEngine.InputSystem.InputAction BuildBarracksAction;
 
+    Entity _barracksPrefabEntity;
+
+    void Start()
+    {
+        var settings = GameObjectConversionSettings.FromWorld(World.DefaultGameObjectInjectionWorld, null);
+        _barracksPrefabEntity = GameObjectConversionUtility.ConvertGameObjectHierarchy(BarracksPrefab, settings);
+    }
+
     void OnEnable() => BuildBarracksAction.Enable();
     void OnDisable() => BuildBarracksAction.Disable();
 
     void Update()
     {
         if (BuildBarracksAction.WasPressedThisFrame())
-            TryBuild(BarracksPrefab, BarracksCost);
+            TryBuild(_barracksPrefabEntity, BarracksCost);
     }
 
-    void TryBuild(GameObject prefab, int cost)
+    void TryBuild(Entity prefab, int cost)
     {
         var ecb = World.DefaultGameObjectInjectionWorld
                      .GetOrCreateSystemManaged<BeginSimulationEntityCommandBufferSystem>()

--- a/Assets/Scripts/EnemySpawnerSystem.cs
+++ b/Assets/Scripts/EnemySpawnerSystem.cs
@@ -3,7 +3,6 @@ using Unity.Burst;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
-using Unity.Physics;
 using Unity.Collections;
 
 [BurstCompile]


### PR DESCRIPTION
## Summary
- make `BuildRequest` use an `Entity` prefab so it can be queried as unmanaged data
- convert selected prefab to an entity in `BuildUI` before issuing `BuildRequest`s
- remove unused `Unity.Physics` using from `EnemySpawnerSystem`

## Testing
- `dotnet build` *(fails: MSB1003 - no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_688e9132a57c832e91ce821fda8b77c3