### PR TITLE
Fix ECS BuildRequest and add missing math import

### DIFF
--- a/Assets/Scripts/BarracksSpawnSystem.cs
+++ b/Assets/Scripts/BarracksSpawnSystem.cs
@@ -3,6 +3,7 @@ using Unity.Burst;
 using Unity.Collections;
 using Unity.Entities;
 using Unity.Transforms;
+using Unity.Mathematics;
 
 [BurstCompile]
 public partial struct BarracksSpawnSystem : ISystem

--- a/Assets/Scripts/BuildRequest.cs
+++ b/Assets/Scripts/BuildRequest.cs
@@ -1,10 +1,9 @@
 using Unity.Entities;
 using Unity.Mathematics;
-using UnityEngine;
 
 public struct BuildRequest : IComponentData
 {
-    public GameObject Prefab;
+    public Entity Prefab;
     public int Cost;
     public float3 BasePosition;
 }

--- a/Assets/Scripts/BuildUI.cs
+++ b/Assets/Scripts/BuildUI.cs
@@ -6,7 +6,7 @@ using Unity.Mathematics;
 public class BuildUI : MonoBehaviour
 {
     public int BarracksCost = 100;
-    public GameObject BarracksPrefab;
+    public Entity BarracksPrefab;
     public BaseAuthoring BaseRef;
     public UnityEngine.InputSystem.InputAction BuildBarracksAction;
 
@@ -19,14 +19,14 @@ public class BuildUI : MonoBehaviour
             TryBuild(BarracksPrefab, BarracksCost);
     }
 
-    void TryBuild(GameObject prefab, int cost)
+    void TryBuild(Entity prefab, int cost)
     {
         var ecb = World.DefaultGameObjectInjectionWorld
                      .GetOrCreateSystemManaged<BeginSimulationEntityCommandBufferSystem>()
                      .CreateCommandBuffer();
 
-        ecb.CreateEntity();
-        ecb.AddComponent(new BuildRequest
+        var request = ecb.CreateEntity();
+        ecb.AddComponent(request, new BuildRequest
         {
             Prefab = prefab,
             Cost = cost,

--- a/Assets/Scripts/EnemySpawnerSystem.cs
+++ b/Assets/Scripts/EnemySpawnerSystem.cs
@@ -3,7 +3,6 @@ using Unity.Burst;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
-using Unity.Physics;
 using Unity.Collections;
 
 [BurstCompile]


### PR DESCRIPTION
## Summary
- make `BuildRequest` use an `Entity` prefab so it can be queried as unmanaged data
- issue build requests from `BuildUI` using an `Entity` prefab and an explicit command buffer entity
- add missing `Unity.Mathematics` import so `BarracksSpawnSystem` can use `quaternion.identity`
- remove unused `Unity.Physics` namespace from `EnemySpawnerSystem`

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688e9132a57c832e91ce821fda8b77c3