### PR TITLE
Simplify prefab handling in BuildUI

### DIFF
--- a/Assets/Scripts/BuildUI.cs
+++ b/Assets/Scripts/BuildUI.cs
@@ -13,8 +13,7 @@ public class BuildUI : MonoBehaviour
 
     void Start()
     {
-        var settings = GameObjectConversionSettings.FromWorld(World.DefaultGameObjectInjectionWorld, null);
-        _barracksPrefabEntity = GameObjectConversionUtility.ConvertGameObjectHierarchy(BarracksPrefab, settings);
+        _barracksPrefabEntity = BarracksPrefab;
     }
 
     void OnEnable() => BuildBarracksAction.Enable();


### PR DESCRIPTION
## Summary
- assign barracks entity prefab directly instead of using removed runtime conversion APIs

## Testing
- `dotnet test` (fails: MSB1003: Specify a project or solution file)


------
https://chatgpt.com/codex/tasks/task_e_688e95dea6fc832eb940fec5cf559e66