### PR TITLE
Refactor building system with prefab registry and placement

### DIFF
--- a/Assets/Scripts/BaseAuthoring.cs
+++ b/Assets/Scripts/BaseAuthoring.cs
@@ -18,6 +18,12 @@ public class BaseAuthoring : MonoBehaviour
                 Rotation = quaternion.identity,
                 Scale = 1
             });
+
+            var slots = AddBuffer<ReservedBuildSlot>(entity);
+            slots.Add(new ReservedBuildSlot { Offset = new float3(5, 0, 0), Occupied = false });
+            slots.Add(new ReservedBuildSlot { Offset = new float3(-5, 0, 0), Occupied = false });
+            slots.Add(new ReservedBuildSlot { Offset = new float3(0, 0, 5), Occupied = false });
+            slots.Add(new ReservedBuildSlot { Offset = new float3(0, 0, -5), Occupied = false });
         }
     }
 }

--- a/Assets/Scripts/BuildRequest.cs
+++ b/Assets/Scripts/BuildRequest.cs
@@ -1,9 +1,6 @@
 using Unity.Entities;
-using Unity.Mathematics;
-
 public struct BuildRequest : IComponentData
 {
     public Entity Prefab;
     public int Cost;
-    public float3 BasePosition;
 }

--- a/Assets/Scripts/BuildRequestSystem.cs
+++ b/Assets/Scripts/BuildRequestSystem.cs
@@ -1,6 +1,5 @@
 // BuildRequestSystem.cs
 using Unity.Burst;
-using Unity.Collections;
 using Unity.Entities;
 using Unity.Mathematics;
 using Unity.Transforms;
@@ -15,33 +14,24 @@ public partial struct BuildRequestSystem : ISystem
 
     public void OnUpdate(ref SystemState state)
     {
-        var ecb = new EntityCommandBuffer(Allocator.Temp);
+        var ecb = SystemAPI.GetSingleton<BeginSimulationEntityCommandBufferSystem.Singleton>().CreateCommandBuffer(state.WorldUnmanaged);
 
-        foreach (var (req, entity) in SystemAPI.Query<RefRO<BuildRequest>>().WithEntityAccess())
+        foreach (var (req, pos, entity) in SystemAPI.Query<RefRO<BuildRequest>, RefRO<BuildPosition>>().WithEntityAccess())
         {
             var gold = SystemAPI.GetSingletonRW<Gold>();
             if (gold.ValueRO.Amount >= req.ValueRO.Cost)
             {
                 gold.ValueRW.Amount -= req.ValueRO.Cost;
-
-                // Find nearest free spot. For demo, use a simple ring increment.
-                float radius = 5f;
-                var pos = req.ValueRO.BasePosition + new float3(radius, 0, 0); // TODO: add more sophisticated placement
-
                 var buildingEntity = ecb.Instantiate(req.ValueRO.Prefab);
                 ecb.SetComponent(buildingEntity, new LocalTransform
                 {
-                    Position = pos,
+                    Position = pos.ValueRO.Value,
                     Rotation = quaternion.identity,
                     Scale = 1
                 });
-
-                // Add the BarracksTag or other data. If prefab already has Building, it will be carried over.
             }
 
             ecb.DestroyEntity(entity);
         }
-
-        ecb.Playback(state.EntityManager);
     }
 }

--- a/Assets/Scripts/BuildUI.cs
+++ b/Assets/Scripts/BuildUI.cs
@@ -5,31 +5,10 @@ using UnityEngine.UI;
 
 public class BuildUI : MonoBehaviour
 {
-    public int BarracksCost = 100;
-    public Entity BarracksPrefab;
-    public BaseAuthoring BaseRef;
+    public int BarracksIndex = 0;
     public UnityEngine.InputSystem.InputAction BuildBarracksAction;
-
-    Entity _barracksPrefabEntity;
-
     void Start()
     {
-        // Cache entity prefab passed from inspector. If none provided, attempt to
-        // locate one converted in the scene by searching for the prefab tag.
-        _barracksPrefabEntity = BarracksPrefab;
-
-        if (_barracksPrefabEntity == Entity.Null)
-        {
-            var em = World.DefaultGameObjectInjectionWorld.EntityManager;
-            var query = em.CreateEntityQuery(typeof(BarracksTag), typeof(Building), typeof(Unity.Entities.Prefab));
-            if (query.CalculateEntityCount() > 0)
-                _barracksPrefabEntity = query.GetSingletonEntity();
-        }
-
-        // Locate base authoring if not linked in inspector.
-        if (BaseRef == null)
-            BaseRef = FindObjectOfType<BaseAuthoring>();
-
         // Hook up UI button automatically so no cross-scene reference is needed.
         var buttonObj = GameObject.Find("BarracksButton");
         if (buttonObj != null)
@@ -46,30 +25,41 @@ public class BuildUI : MonoBehaviour
     void Update()
     {
         if (BuildBarracksAction.WasPressedThisFrame())
-            TryBuild(_barracksPrefabEntity, BarracksCost);
+            TryBuild(BarracksIndex);
     }
 
     // Allow UI buttons to trigger barracks construction.
     public void BuildBarracks()
     {
-        TryBuild(_barracksPrefabEntity, BarracksCost);
+        TryBuild(BarracksIndex);
     }
 
-    void TryBuild(Entity prefab, int cost)
+    void TryBuild(int prefabIndex)
     {
-        if (prefab == Entity.Null || BaseRef == null)
+        var world = World.DefaultGameObjectInjectionWorld;
+        if (world == null)
+            return;
+        var em = world.EntityManager;
+        var query = em.CreateEntityQuery(ComponentType.ReadOnly<BuildingPrefabRegistry>());
+        if (query.CalculateEntityCount() == 0)
             return;
 
-        var ecb = World.DefaultGameObjectInjectionWorld
+        var registryEntity = query.GetSingletonEntity();
+        var buffer = em.GetBuffer<BuildingPrefabElement>(registryEntity);
+        if (prefabIndex < 0 || prefabIndex >= buffer.Length)
+            return;
+
+        var element = buffer[prefabIndex];
+
+        var ecb = world
                      .GetOrCreateSystemManaged<BeginSimulationEntityCommandBufferSystem>()
                      .CreateCommandBuffer();
 
         var request = ecb.CreateEntity();
         ecb.AddComponent(request, new BuildRequest
         {
-            Prefab = prefab,
-            Cost = cost,
-            BasePosition = BaseRef.transform.position
+            Prefab = element.Prefab,
+            Cost = element.Cost
         });
     }
 }

--- a/Assets/Scripts/BuildingPlacementSystem.cs
+++ b/Assets/Scripts/BuildingPlacementSystem.cs
@@ -1,0 +1,46 @@
+using Unity.Burst;
+using Unity.Entities;
+using Unity.Mathematics;
+using Unity.Transforms;
+
+public struct ReservedBuildSlot : IBufferElementData
+{
+    public float3 Offset;
+    public bool Occupied;
+}
+
+public struct BuildPosition : IComponentData
+{
+    public float3 Value;
+}
+
+[BurstCompile]
+public partial struct BuildingPlacementSystem : ISystem
+{
+    public void OnUpdate(ref SystemState state)
+    {
+        if (!SystemAPI.HasSingleton<BaseTag>())
+            return;
+
+        var baseEntity = SystemAPI.GetSingletonEntity<BaseTag>();
+        var baseTransform = SystemAPI.GetComponent<LocalTransform>(baseEntity);
+        var slots = SystemAPI.GetBuffer<ReservedBuildSlot>(baseEntity);
+        var ecb = SystemAPI.GetSingleton<BeginSimulationEntityCommandBufferSystem.Singleton>().CreateCommandBuffer(state.WorldUnmanaged);
+
+        foreach (var (req, entity) in SystemAPI.Query<RefRO<BuildRequest>>().WithNone<BuildPosition>().WithEntityAccess())
+        {
+            for (int i = 0; i < slots.Length; i++)
+            {
+                var slot = slots[i];
+                if (slot.Occupied)
+                    continue;
+
+                slot.Occupied = true;
+                slots[i] = slot;
+                var pos = baseTransform.Position + slot.Offset;
+                ecb.AddComponent(entity, new BuildPosition { Value = pos });
+                break;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/BuildingPlacementSystem.cs.meta
+++ b/Assets/Scripts/BuildingPlacementSystem.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 234567890abcdef1234567890abcdef1

--- a/Assets/Scripts/BuildingPrefabsAuthoring.cs
+++ b/Assets/Scripts/BuildingPrefabsAuthoring.cs
@@ -1,0 +1,41 @@
+using System.Collections.Generic;
+using Unity.Entities;
+using UnityEngine;
+
+[DisallowMultipleComponent]
+public class BuildingPrefabsAuthoring : MonoBehaviour
+{
+    [System.Serializable]
+    public struct Entry
+    {
+        public GameObject Prefab;
+        public int Cost;
+    }
+
+    public List<Entry> Prefabs = new();
+
+    public class Baker : Baker<BuildingPrefabsAuthoring>
+    {
+        public override void Bake(BuildingPrefabsAuthoring authoring)
+        {
+            var entity = GetEntity(TransformUsageFlags.None);
+            AddComponent<BuildingPrefabRegistry>(entity);
+            var buffer = AddBuffer<BuildingPrefabElement>(entity);
+            foreach (var entry in authoring.Prefabs)
+            {
+                if (entry.Prefab == null)
+                    continue;
+                var prefabEntity = GetEntity(entry.Prefab, TransformUsageFlags.Dynamic);
+                buffer.Add(new BuildingPrefabElement { Prefab = prefabEntity, Cost = entry.Cost });
+            }
+        }
+    }
+}
+
+public struct BuildingPrefabRegistry : IComponentData { }
+
+public struct BuildingPrefabElement : IBufferElementData
+{
+    public Entity Prefab;
+    public int Cost;
+}

--- a/Assets/Scripts/BuildingPrefabsAuthoring.cs.meta
+++ b/Assets/Scripts/BuildingPrefabsAuthoring.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 34567890abcdef1234567890abcdef2


### PR DESCRIPTION
## Summary
- Add building prefab registry and buffer for prefab costs
- Simplify build requests and UI to use registry lookup
- Reserve build slots around the base and spawn buildings via placement system

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688f6c6cd498832e936b86281e281a3b